### PR TITLE
Removed PHP variables in favor of includes variables.

### DIFF
--- a/templates/elements/buildings/navigation/nav-primary.php
+++ b/templates/elements/buildings/navigation/nav-primary.php
@@ -1,4 +1,4 @@
   <nav id="site-navigation" class="main-navigation" role="navigation">
-    <button class="menu-toggle" aria-controls="menu" aria-expanded="false"><?php _e( 'Primary Menu', $appSlug ); ?></button>
+    <button class="menu-toggle" aria-controls="menu" aria-expanded="false"><?php _e( 'Primary Menu', '@@appNameSlug' ); ?></button>
     <?php wp_nav_menu( array( 'theme_location' => 'primary' ) ); ?>
   </nav><!-- #site-navigation -->

--- a/templates/elements/structures/global/header.php
+++ b/templates/elements/structures/global/header.php
@@ -11,14 +11,16 @@
 
 <body <?php body_class(); ?>>
 <div id="page" class="hfeed site">
-	<a class="skip-link screen-reader-text" href="#content"><?php _e( 'Skip to content', $appSlug ); ?></a>
+	<a class="skip-link screen-reader-text" href="#content"><?php _e( 'Skip to content', '@@appNameSlug' ); ?></a>
 
 	<header id="masthead" class="site-header" role="banner">
 		@@if( siteBranding === "Yes" ) {
 			@@include( './elements/structures/global/branding.php' )
 		}
 		@@if( primaryNav === "Yes" ) {
-			@@include( './elements/buildings/navigation/nav-primary.php' )
+			@@include( './elements/buildings/navigation/nav-primary.php', {
+				"appNameSlug": "@@appNameSlug"
+			} )
 		}
 	</header><!-- #masthead -->
 

--- a/templates/header.php
+++ b/templates/header.php
@@ -7,6 +7,6 @@
  * @package <%= appName %>
  */
 
-$appSlug = '<%= appNameSlug %>';
-
-@@include( './elements/structures/global/header.php' )
+@@include( './elements/structures/global/header.php', {
+	"appNameSlug": "<%= appNameSlug %>"
+} )


### PR DESCRIPTION
PHP variables will not work in I18N translation function. Removed this approach and utilized gulp-file-include variable functionality. Caveat is that the variable needs to be passed by each include call as a secondary parameter object.
