### PR TITLE
Reverted site-logo call in favor of theme prefix route

### DIFF
--- a/templates/inc/jetpack.php
+++ b/templates/inc/jetpack.php
@@ -49,7 +49,7 @@ add_action( 'after_setup_theme', '<%= appNameVar %>_site_logo_init' );
  *
  * @since <%= appName %> 1.0
  */
-function component_s_the_site_logo() {
+function <%= appNameVar %>_the_site_logo() {
 	if ( ! function_exists( 'jetpack_the_site_logo' ) ) {
 		return;
 	} else {

--- a/templates/src/site-logo/site-logo.php
+++ b/templates/src/site-logo/site-logo.php
@@ -1,1 +1,1 @@
-<?php if ( function_exists( jetpack_the_site_logo ) ) jetpack_the_site_logo(); ?>
+<?php <%= appNameVar %>_the_site_logo(); ?>


### PR DESCRIPTION
This was done originally but updated to fix an undefined fn error in the generator.
Decided on an alternative route for the fix in the generator.
