### PR TITLE
Fix Infinite Scroll behaviour

### DIFF
--- a/templates/inc/jetpack.php
+++ b/templates/inc/jetpack.php
@@ -29,7 +29,7 @@ add_action( 'after_setup_theme', '<%= appNameVar %>_jetpack_setup' );
 function <%= appNameVar %>_infinite_scroll_render() {
 	while ( have_posts() ) {
 		the_post();
-		get_template_part( 'template-parts/content', get_post_format() );
+		get_template_part( 'components/content', get_post_format() );
 	}
 } // end function <%= appNameVar %>_infinite_scroll_render
 


### PR DESCRIPTION
Infinite Scroll was trying to use a template part that didn't exist, resulting in the posts failing to load entirely and driving me crazy for three days. Correcting the path here solves the problem!

Solves #85.
